### PR TITLE
 Does not work with PHP version 7.3 and above. I propose to fix this

### DIFF
--- a/src/Template/Docx/DocxTemplate.php
+++ b/src/Template/Docx/DocxTemplate.php
@@ -261,7 +261,7 @@ class DocxTemplate {
                                         if (array_key_exists('repeatDelimiter', $keyOptions)) {
                                             $textContent = trim($textContent, $keyOptions['repeatDelimiter']);
                                         }
-                            			continue;
+                            			continue 2;
                             		}else{
                             			if($this->development){
                             				// in development mode , show the unprocessed keys in output


### PR DESCRIPTION
Since PHP 7.3, if the interpreter sees a continue without a 2 inside a switch inside a loop, it will issue Warning: "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"?

From php documentation -  
Note that, unlike some other languages, the continue statement is used in switch statements and acts like a break statement. If you have a switch statement inside a loop and you need to go to the next iteration of the loop, use continue 2.   https://www.php.net/manual/ru/control-structures.switch.php